### PR TITLE
Add CDATA tags for HTML compliance

### DIFF
--- a/lib/event_tracker.rb
+++ b/lib/event_tracker.rb
@@ -24,6 +24,7 @@ module EventTracker
       if insert_at
         trackers = []
         a = [ %q{<script type="text/javascript">} ]
+        a << %q{//<![CDATA[}
 
         if mixpanel_key
           trackers << EventTracker::Mixpanel
@@ -53,7 +54,9 @@ module EventTracker
             end
           end
         end
+        a << %q{//]]>}
         a << %q{</script>}
+
         body.insert insert_at, a.join("\n")
         response.body = body
       end


### PR DESCRIPTION
Add CDATA tags for HTML compliance.

Gets rid of annoying messages when we're running tests with Test::Unit

For example:

```
Loaded suite /vagrant/vendor/gems/ruby/1.8/gems/rake-0.9.6/lib/rake/rake_test_loader
Started
.ignoring attempt to close h.length;e++)d(g,h[e]); with script
  opened at byte 2049, line 53
  closed at byte 2203, line 57
  attributes at open: {"a"=>true}
  text around open: "ncrement'];for(e=0;e<h.length;e++)d(g,h["
  text around close: "0374cc93b70186a\");\n\n</script></head>\n<bo"
```
