### PR TITLE
Added a line of documentation to the ReadMe for using the mixpanel_people_set method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ end
 # in controller or views
 track_event("Event Name", optional_property: "value")
 register_properties(name: "value")
+mixpanel_people_set( "property" => "value", "property" => "value")
 ```
 
 ## Todos


### PR DESCRIPTION
I thought it'd be helpful to add this line to the ReadMe doc. It took me a little bit to work out the syntax for the mixpanel_people_set method since several of the properties require $. For example: 

```
mixpanel_people_set( '$name' => "#{current_user.name}", '$email' => "#{current_user.email}")
```
