### PR TITLE
Add Google Analytics support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Or install it yourself as:
 # config/application.rb
 config.event_tracker.mixpanel_key = "YOUR_KEY"
 config.event_tracker.kissmetrics_key = "YOUR_KEY"
+config.event_tracker.google_analytics_key = "YOUR_KEY"
 
 class ApplicationController < ActionController::Base
   around_filter :append_event_tracking_tags

--- a/lib/event_tracker/google_analytics.rb
+++ b/lib/event_tracker/google_analytics.rb
@@ -1,0 +1,21 @@
+class EventTracker::GoogleAnalytics
+  def initialize(key)
+    @key = key
+  end
+
+  def init
+    <<-EOD
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '#{@key}', 'auto', {'name': 'event_tracker'});
+      ga('event_tracker.send', 'pageview');
+    EOD
+  end
+
+  def track(event_name, properties = {})
+    %Q{ga('event_tracker.send', 'event', 'event_tracker', '#{event_name}');}
+  end
+end

--- a/spec/event_tracker_spec.rb
+++ b/spec/event_tracker_spec.rb
@@ -4,6 +4,7 @@ shared_examples_for "init" do
   subject { page.find("head script").native.content }
   it { should include('mixpanel.init("YOUR_TOKEN")') }
   it { should include(%q{var _kmk = _kmk || 'KISSMETRICS_KEY'}) }
+  it { should include(%q{ga('create', 'GOOGLE_ANALYTICS_KEY', 'auto', {'name': 'event_tracker'});}) }
 end
 
 shared_examples_for "without distinct id" do
@@ -18,11 +19,13 @@ end
 
 shared_examples_for "without event" do
   it { should_not include('mixpanel.track("Register for site")') }
+  it { should_not include(%q{ga('event_tracker.send', 'event', 'event_tracker', 'Register for site');}) }
 end
 
 shared_examples_for "with event" do
   it { should include('mixpanel.track("Register for site")') }
   it { should include(%q{_kmq.push(['record', 'Register for site']);}) }
+  it { should include(%q{ga('event_tracker.send', 'event', 'event_tracker', 'Register for site');}) }
 end
 
 feature 'basic integration' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ app.config.action_dispatch.show_exceptions = false
 
 app.config.event_tracker.mixpanel_key = "YOUR_TOKEN"
 app.config.event_tracker.kissmetrics_key = "KISSMETRICS_KEY"
+app.config.event_tracker.google_analytics_key = "GOOGLE_ANALYTICS_KEY"
 
 app.initialize!
 


### PR DESCRIPTION
This implementation will not track properties, but just events.
Using the [Google event tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/events), the event action is tracked under `event_tracker` category.
As part of script initialization, it also sends a `pageview` every time the analytics script is included in the header.
