### PR TITLE
Add ability to apply events and people properties to an alternate identity

### DIFF
--- a/event_tracker.gemspec
+++ b/event_tracker.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rails', '>= 3.0'
   gem.add_development_dependency 'steak'
   gem.add_development_dependency 'capybara', '~> 2.0.3'
+  gem.add_development_dependency 'rspec-rails', '~> 2.14.0'
 end

--- a/spec/event_tracker_spec.rb
+++ b/spec/event_tracker_spec.rb
@@ -242,7 +242,42 @@ feature 'basic integration' do
     def halt_the_chain_and_render
       render inline: "OK", layout: true and return
     end
+  end
+    
+  # Mixpanel Alternate Identity Tracking
+  class AlternateIdentityController < ApplicationController
+    around_filter :append_event_tracking_tags
+    def identity_switch
+      mixpanel_alternate_identify "Another User"
+      render inline: "OK", layout: true
+    end
 
+    def people_set
+      mixpanel_alternate_identify "Another User"
+      mixpanel_people_set "Foo" => "Bar"
+      render inline: "OK", layout: true
+    end
+
+    def people_increment
+      mixpanel_alternate_identify "Another User"
+      mixpanel_alternate_people_increment "Named Attribute"
+      render inline: "OK", layout: true
+    end
+  end
+
+  context 'alternate identity tracking' do
+    background { visit '/alternate_identity/identity_switch' }
+    it { should include %Q{mixpanel.identify("Another User")} }
+  end
+
+  context 'alternate identity tracking with people set' do
+    background { visit '/alternate_identity/people_set' }
+    it { should include %Q{mixpanel.people.set({"Foo":"Bar"})} }
+  end
+
+  context 'alternate identity tracking with people increment' do
+    background { visit '/alternate_identity/people_increment' }
+    it { should include %Q{mixpanel.people.increment(["Named Attribute"])} }
   end
 
 end

--- a/spec/event_tracker_spec.rb
+++ b/spec/event_tracker_spec.rb
@@ -254,7 +254,7 @@ feature 'basic integration' do
 
     def people_set
       mixpanel_alternate_identify "Another User"
-      mixpanel_people_set "Foo" => "Bar"
+      mixpanel_alternate_people_set "Foo" => "Bar"
       render inline: "OK", layout: true
     end
 


### PR DESCRIPTION
For Mixpanel this would be used for example in a message forum, when a new comment is added to a post, to increment the comments count on the identity of the original poster. The Javascript added to the end of the page outputs as normal, then switches identity, then adds the usual mixpanel.track, mixpanel.people.set, mixpanel.people.increment etc calls to be applied to that alternate identity.