### PR TITLE
Don't include helper methods on API controllers

### DIFF
--- a/lib/event_tracker.rb
+++ b/lib/event_tracker.rb
@@ -108,7 +108,7 @@ module EventTracker
       ActiveSupport.on_load :action_controller do
         include ActionControllerExtension
         include HelperMethods
-        helper HelperMethods
+        helper HelperMethods if respond_to?(:helper)
       end
     end
   end


### PR DESCRIPTION
Rails 5's controllers were split in two (API and Base), we can't safely assume all controllers have the helper method.

FYI: [Don't include layout on API controllers by josepjaume · Pull Request #582 ·AjuntamentdeBarcelona/decidim](https://github.com/AjuntamentdeBarcelona/decidim/pull/582)